### PR TITLE
Init windows bringup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ catkin_package(
   LIBRARIES ${PROJECT_NAME}
   )
 
+if(MSVC)
+  add_definitions(-DNON_POLLING)
+endif()
+
 add_library(${PROJECT_NAME} src/realtime_clock.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -23,7 +27,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 install(TARGETS ${PROJECT_NAME}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
 install(DIRECTORY scripts/
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
* By default we choose NON_POLLING implementation on Windows since the polling mode is using some posix-only APIs.