### PR TITLE
Add back typedef for ResultPtr & FeedbackPtr

### DIFF
--- a/include/realtime_tools/realtime_server_goal_handle.h
+++ b/include/realtime_tools/realtime_server_goal_handle.h
@@ -47,6 +47,8 @@ private:
   ACTION_DEFINITION(Action);
 
   typedef actionlib::ServerGoalHandle<Action> GoalHandle;
+  typedef boost::shared_ptr<Result> ResultPtr;
+  typedef boost::shared_ptr<Feedback> FeedbackPtr;
 
   uint8_t state_;
 


### PR DESCRIPTION
Add back typedef for ResultPtr & FeedbackPtr because of actionlib recent changes: https://github.com/ros/actionlib/pull/113